### PR TITLE
Update Makefile to be usable from 4.0.x to 4.2.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 PROJECT = rabbitmq_lvc_exchange
 PROJECT_DESCRIPTION = RabbitMQ Last Value Cache exchange
 
-RABBITMQ_VERSION ?= v4.1.x
+RABBITMQ_VERSION ?= v4.2.x
 current_rmq_ref = $(RABBITMQ_VERSION)
 
 define PROJECT_APP_EXTRA_KEYS
-	{broker_version_requirements, ["4.1.0"]}
+	{broker_version_requirements, ["4.0.0", "4.1.0", "4.2.0"]}
 endef
 
 dep_amqp_client                = git_rmq-subfolder rabbitmq-erlang-client $(RABBITMQ_VERSION)


### PR DESCRIPTION
`make ct` passes

but eunit tests fail

```
 GEN    eunit
  There were no tests to run.
 GEN    beam-cache-restore-app
  Creating PLT /home/lois/.local_rabbit/rabbitmq-server/deps/rabbitmq-lvc-exchange/.rabbitmq_lvc_exchange.plt ...=ERROR REPORT==== 12-Nov-2025::11:15:35.813008 ===
Error in process <0.768.0> with exit value:
{undef,
    [{elixir_erl,debug_info,
         [core_v1,'Elixir.RabbitCommon.Records',
```

This happens without the changes, so maybe we can address that problem on a different PR.