### PR TITLE
Remove leading v from rabbitmq version in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT = rabbitmq_lvc_exchange
 PROJECT_DESCRIPTION = RabbitMQ Last Value Cache exchange
 
-RABBITMQ_VERSION ?= v4.2.x
+RABBITMQ_VERSION ?= 4.2.0
 current_rmq_ref = $(RABBITMQ_VERSION)
 
 define PROJECT_APP_EXTRA_KEYS

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT = rabbitmq_lvc_exchange
 PROJECT_DESCRIPTION = RabbitMQ Last Value Cache exchange
 
-RABBITMQ_VERSION ?= 4.2.0
+RABBITMQ_VERSION ?= 4.0.0
 current_rmq_ref = $(RABBITMQ_VERSION)
 
 define PROJECT_APP_EXTRA_KEYS


### PR DESCRIPTION
The `RABBITMQ_VERSION` var in Makefile seems to not have other use than setting the generated plugin name and setting the `vsn` file in the `rabbitmq_lvc_exchange.app` file. 